### PR TITLE
Backfill daily_prices gap and add scraper to CI/CD

### DIFF
--- a/.aws/task-definition-scraper.json
+++ b/.aws/task-definition-scraper.json
@@ -1,0 +1,44 @@
+{
+  "family": "fuel-finder-scraper-auto",
+  "networkMode": "awsvpc",
+  "requiresCompatibilities": ["FARGATE"],
+  "cpu": "256",
+  "memory": "512",
+  "executionRoleArn": "arn:aws:iam::028597908565:role/fuel-finder-ecs-execution",
+  "taskRoleArn": "arn:aws:iam::028597908565:role/fuel-finder-ecs-task",
+  "containerDefinitions": [
+    {
+      "name": "scraper",
+      "image": "PLACEHOLDER",
+      "essential": true,
+      "command": ["python", "scrape.py", "auto"],
+      "environment": [
+        { "name": "S3_BUCKET", "value": "fuel-finder-raw" },
+        { "name": "AWS_REGION", "value": "eu-north-1" },
+        { "name": "SKIP_S3", "value": "false" }
+      ],
+      "secrets": [
+        {
+          "name": "DATABASE_URL",
+          "valueFrom": "arn:aws:secretsmanager:eu-west-2:028597908565:secret:fuel-finder-prod/DATABASE_URL"
+        },
+        {
+          "name": "FUEL_API_ID",
+          "valueFrom": "arn:aws:secretsmanager:eu-west-2:028597908565:secret:fuel-finder-prod/FUEL_API_ID"
+        },
+        {
+          "name": "FUEL_API_SECRET",
+          "valueFrom": "arn:aws:secretsmanager:eu-west-2:028597908565:secret:fuel-finder-prod/FUEL_API_SECRET"
+        }
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/fuel-finder",
+          "awslogs-region": "eu-west-2",
+          "awslogs-stream-prefix": "scraper"
+        }
+      }
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ env:
   ECS_CLUSTER: fuel-finder
   ECS_SERVICE_PROD: fuel-finder-prod
   TASK_DEF_PROD: .aws/task-definition-prod.json
+  SCRAPER_AWS_REGION: eu-west-2
+  TASK_DEF_SCRAPER: .aws/task-definition-scraper.json
 
 jobs:
   # ── 1. Unit tests (all branches + PRs) ─────────────────────────────
@@ -89,18 +91,30 @@ jobs:
           curl -sf --retry 3 --retry-delay 2 http://localhost:8080/health
           docker compose down
 
-      - name: Save image for ECR push
+      - name: Build scraper image
+        run: docker build -t fuel-finder-scraper -f Dockerfile .
+
+      - name: Save images for ECR push
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
           IMAGE_NAME=$(docker compose config --images | grep web | head -1)
           docker save "$IMAGE_NAME" | gzip > /tmp/fuel-finder-web.tar.gz
+          docker save fuel-finder-scraper | gzip > /tmp/fuel-finder-scraper.tar.gz
 
-      - name: Upload image artifact
+      - name: Upload web image artifact
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@v6
         with:
           name: docker-image
           path: /tmp/fuel-finder-web.tar.gz
+          retention-days: 1
+
+      - name: Upload scraper image artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v6
+        with:
+          name: docker-image-scraper
+          path: /tmp/fuel-finder-scraper.tar.gz
           retention-days: 1
 
   # ── 3. Push to ECR (main branch only) ──────────────────────────────
@@ -179,3 +193,80 @@ jobs:
           service: ${{ env.ECS_SERVICE_PROD }}
           cluster: ${{ env.ECS_CLUSTER }}
           wait-for-service-stability: true
+
+  # ── 5. Push scraper image to ECR eu-west-2 (main branch only) ─────
+  push-ecr-scraper:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    needs: docker
+    timeout-minutes: 10
+    outputs:
+      image: ${{ steps.push.outputs.image }}
+
+    steps:
+      - name: Download scraper image artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: docker-image-scraper
+          path: /tmp
+
+      - name: Load Docker image
+        run: gunzip -c /tmp/fuel-finder-scraper.tar.gz | docker load
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.SCRAPER_AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: ecr-login
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Tag and push image
+        id: push
+        env:
+          ECR_REGISTRY: ${{ steps.ecr-login.outputs.registry }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          IMAGE="$ECR_REGISTRY/$ECR_REPOSITORY"
+          docker tag fuel-finder-scraper:latest "$IMAGE:scraper-$IMAGE_TAG"
+          docker tag fuel-finder-scraper:latest "$IMAGE:scraper-latest"
+          docker push "$IMAGE:scraper-$IMAGE_TAG"
+          docker push "$IMAGE:scraper-latest"
+          echo "image=$IMAGE:scraper-$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+
+  # ── 6. Register scraper task definitions (main branch only) ────────
+  deploy-scraper:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    needs: push-ecr-scraper
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.SCRAPER_AWS_REGION }}
+
+      - name: Register scraper task definitions
+        env:
+          SCRAPER_IMAGE: ${{ needs.push-ecr-scraper.outputs.image }}
+        run: |
+          for mode in auto incremental full; do
+            # Render image into task definition and override family + command
+            jq --arg img "$SCRAPER_IMAGE" \
+               --arg family "fuel-finder-scraper-$mode" \
+               --arg mode "$mode" \
+               '.family = $family
+                | .containerDefinitions[0].image = $img
+                | .containerDefinitions[0].command = ["python", "scrape.py", $mode]' \
+               "$TASK_DEF_SCRAPER" > /tmp/task-def-scraper-${mode}.json
+
+            aws ecs register-task-definition \
+              --cli-input-json file:///tmp/task-def-scraper-${mode}.json
+            echo "Registered fuel-finder-scraper-$mode"
+          done

--- a/migrations/021_backfill_daily_prices.sql
+++ b/migrations/021_backfill_daily_prices.sql
@@ -1,0 +1,21 @@
+-- Backfill daily_prices for any dates missing since the initial migration 018
+-- backfill.  The scraper image in ECR predated the refresh_daily_prices()
+-- call so no new rows were written after the 018 backfill ran.
+
+INSERT INTO daily_prices (node_id, fuel_type, price_date, avg_price, min_price, max_price, sample_count)
+SELECT fp.node_id,
+       fp.fuel_type,
+       DATE(fp.observed_at),
+       ROUND(AVG(COALESCE(pc.corrected_price, fp.price))::numeric, 1),
+       ROUND(MIN(COALESCE(pc.corrected_price, fp.price))::numeric, 1),
+       ROUND(MAX(COALESCE(pc.corrected_price, fp.price))::numeric, 1),
+       COUNT(*)
+FROM fuel_prices fp
+LEFT JOIN price_corrections pc ON pc.fuel_price_id = fp.id
+WHERE fp.anomaly_flags IS NULL
+GROUP BY fp.node_id, fp.fuel_type, DATE(fp.observed_at)
+ON CONFLICT (node_id, fuel_type, price_date) DO UPDATE SET
+    avg_price    = EXCLUDED.avg_price,
+    min_price    = EXCLUDED.min_price,
+    max_price    = EXCLUDED.max_price,
+    sample_count = EXCLUDED.sample_count;


### PR DESCRIPTION
The scraper Docker image in ECR eu-west-2 was last pushed on March 26, before refresh_daily_prices() was added to scrape.py (March 30). The running scraper never populated daily_prices after the initial migration 018 backfill, causing trend charts to stop at March 30.

Fix:
- Migration 021: re-aggregate all fuel_prices into daily_prices with ON CONFLICT DO UPDATE to fill the gap (March 31 – present)
- Add scraper image build/push to CI/CD pipeline (eu-west-2 ECR)
- Add task definition registration for all three scraper variants (auto, incremental, full)
- Add .aws/task-definition-scraper.json template